### PR TITLE
fix: user can check --help even without valid URI

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,13 +5,18 @@ import os
 
 from dotenv import load_dotenv
 from opensearchpy import OpenSearch
+from customized_exceptions import InvalidServiceURI
 
-load_dotenv()
 
-INDEX_NAME = "epicurious-recipes"
-SERVICE_URI = os.getenv("SERVICE_URI")
-if SERVICE_URI == "https://user:pass@hostname:port" or SERVICE_URI is None:
-    print(f"Update SERVICE_URI to your cluster uri. Current value for SERVICE_URI={SERVICE_URI}")
-    exit(-1)
+INDEX_NAME = "recipes"
 
-client = OpenSearch(SERVICE_URI, use_ssl=True)
+
+def create_client():
+    """Create OpenSearch client."""
+    load_dotenv()
+    SERVICE_URI = os.getenv("SERVICE_URI")
+    if SERVICE_URI == "https://user:pass@hostname:port" or SERVICE_URI is None:
+        raise InvalidServiceURI(
+            f"Update SERVICE_URI to your cluster uri. Current value for SERVICE_URI={SERVICE_URI}"
+        )
+    return OpenSearch(SERVICE_URI, use_ssl=True)

--- a/index.py
+++ b/index.py
@@ -13,7 +13,7 @@ from pprint import pprint
 import typer
 from opensearchpy import NotFoundError, helpers, OpenSearch
 
-from config import INDEX_NAME, client
+from config import INDEX_NAME, create_client
 
 
 app = typer.Typer()
@@ -34,6 +34,7 @@ def load_data():
 
     data = load_data()
     print(f"Ingesting {INDEX_NAME} data")
+    client = create_client()
     response = helpers.bulk(client, data)
     print(f"Data sent to your OpenSearch with response: {response}")
 
@@ -41,12 +42,14 @@ def load_data():
 @app.command("delete-index")
 def delete_index(index_name=INDEX_NAME):
     """Delete all the documents of certain index name, and do not raise exceptions"""
+    client = create_client()
     client.indices.delete(index=index_name, ignore=[400, 404])
 
 
 @app.command("get-cluster-info")
 def get_cluster_info():
     """Get information about your OpenSearch cluster"""
+    client = create_client()
     return pprint(OpenSearch.info(client), width=100, indent=1)
 
 
@@ -54,6 +57,7 @@ def get_cluster_info():
 def get_mapping():
     """Retrieve mapping for the index.
     The mapping lists all the fields and their data types."""
+    client = create_client()
 
     # list of all the cluster's indices
     indices = client.indices.get_alias("*").keys()

--- a/search.py
+++ b/search.py
@@ -9,17 +9,19 @@ Run the following to check the available methods:
 """
 import typer
 
-from config import INDEX_NAME, SERVICE_URI, client
+from config import INDEX_NAME, SERVICE_URI, create_client
 from helpers import log_titles
 from typing import List
 
 app = typer.Typer()
+
 
 @app.command("match")
 def search_match(field: str, query: str, operator: str = "or") -> None:
     """Perform search by relevance for certain field and query."""
     typer.echo(f"Searching for {query} in the field {field} \n")
     query_body = {"query": {"match": {field: {"query": query, "operator": operator}}}}
+    client = create_client()
     resp = client.search(index=INDEX_NAME, body=query_body)
     log_titles(resp)
 
@@ -29,6 +31,7 @@ def search_multi_match(fields: List[str], query: str) -> None:
     """Perform search by relevance for certain field and query."""
     typer.echo(f"Searching for {query} in the field {fields} \n")
     query_body = {"query": {"multi_match": {"query": query, "fields": fields}}}
+    client = create_client()
     resp = client.search(index=INDEX_NAME, body=query_body)
     log_titles(resp)
 
@@ -38,6 +41,7 @@ def search_match_phrase(field, query):
     """Search by match phrase for specific phrases in a field."""
     typer.echo(f"Searching for {query} in the field {field}")
     query_body = {"query": {"match_phrase": {field: {"query": query}}}}
+    client = create_client()
     resp = client.search(index=INDEX_NAME, body=query_body)
     log_titles(resp)
 
@@ -47,6 +51,7 @@ def search_range(field: str, gte, lte) -> None:
     """Search by specifying a range of values for a field"""
     typer.echo(f"Searching for values in the {field} ranging from {gte} to {lte} \n")
     query_body = {"query": {"range": {field: {"gte": gte, "lte": lte}}}}
+    client = create_client()
     resp = client.search(index=INDEX_NAME, body=query_body)
     log_titles(resp)
 
@@ -67,6 +72,7 @@ def search_fuzzy(field, value, fuzziness) -> None:
             }
         }
     }
+    client = create_client()
     resp = client.search(index=INDEX_NAME, body=query_body)
     log_titles(resp)
 
@@ -85,6 +91,7 @@ def search_query_string(field: str, query: str, size: int) -> None:
             }
         }
     }
+    client = create_client()
     resp = client.search(index=INDEX_NAME, body=query_body, size=size)
     log_titles(resp)
 
@@ -94,6 +101,7 @@ def search_slop(field, query, slop):
     """Search by specifying a slop - a distance between search word"""
     typer.echo(f"Searching for {query} with slop value {slop} in the field {field}")
     query_body = {"query": {"match_phrase": {field: {"query": query, "slop": slop}}}}
+    client = create_client()
     resp = client.search(index=INDEX_NAME, body=query_body)
     log_titles(resp)
 
@@ -113,6 +121,7 @@ def search_combined_queries():
             }
         }
     }
+    client = create_client()
     resp = client.search(index=INDEX_NAME, body=query_body)
     log_titles(resp)
 


### PR DESCRIPTION
To create a client to make operations, we need
a valid service URI.
Before an invalid service URI exits the program
and show a message for the user to fix the URI.

This way, the user can not see the help command
information from the CLI itself even before deci-
ding to use.

I am creating the client at function level.

Creating a client for every function call is
not the right approach. But for a purpose demo,
seems reasonable.

This way the user can check the --help function
before deciding to use the tool.